### PR TITLE
Use of double quotes (") instead of grave accents (`)

### DIFF
--- a/prolog/tokenize.pl
+++ b/prolog/tokenize.pl
@@ -96,7 +96,7 @@ tokenize(Text, Tokens) :-
 %   * a word (contiguous alpha-numeric chars): `word(W)`
 %   * a punctuation mark (determined by `char_type(C, punct)`): `punct(P)`
 %   * a control character (determined by `char_typ(C, cntrl)`): `cntrl(C)`
-%   * a space ( == ` `): `spc(S)`.
+%   * a space ( == " "): `spc(S)`.
 %
 %  Valid options are:
 %
@@ -240,7 +240,7 @@ tokens([T|Ts]) --> token(T), tokens(Ts).
 %% tokens(_)   --> {length(L, 200)}, L, {format(L)}, halt, !. % For debugging.
 
 token(word(W))     --> word(W), call(eos), !.
-token(word(W)),` ` --> word(W), ` `.
+token(word(W))," " --> word(W), " ".
 token(word(W)), C  --> word(W), (punct(C) ; cntrl(C) ; nasciis(C)).
 token(spc(S))      --> spc(S).
 token(punct(P))    --> punct(P).
@@ -248,7 +248,7 @@ token(cntrl(C))    --> cntrl(C).
 token(other(O))    --> nasciis(O).
 
 
-spc(` `) --> ` `.
+spc(" ") --> " ".
 
 sep --> ' '.
 sep --> call(eos), !.


### PR DESCRIPTION
Some days ago, I started developing a parser with Prolog (using DCGs) and I decided to use your _tokenizer_ as the _lexer_. Then, I wanted to use the traditional mode (`swipl --traditional`) to test it, but a pair of errors (from the _tokenizer_) appeared when compiling my parser.

These errors were due to grave accents (`), which are not compatible with previous systems of Prolog. I replaced them with double quotes ("), that I think are equivalent in this case.
This makes the _tokenizer_ compatible with previous versions of SWI-Prolog.

Anyways, I think the use of grave accents is non-standard when working with Prolog.
